### PR TITLE
Bugfix - Reverse order of the stylesheets

### DIFF
--- a/src/initStyles.js
+++ b/src/initStyles.js
@@ -25,7 +25,7 @@ export function initStyles(shadowDom, styleTargets) {
 
   const newStyle = new CSSStyleSheet()
 
-  for (const styleRule of documentStyles.reverse()) {
+  for (const styleRule of [...documentStyles].reverse()) {
     if (
       styleRule instanceof CSSStyleRule &&
       styleRule.selectorText === ':root'

--- a/src/initStyles.js
+++ b/src/initStyles.js
@@ -25,7 +25,7 @@ export function initStyles(shadowDom, styleTargets) {
 
   const newStyle = new CSSStyleSheet()
 
-  for (const styleRule of documentStyles) {
+  for (const styleRule of documentStyles.reverse()) {
     if (
       styleRule instanceof CSSStyleRule &&
       styleRule.selectorText === ':root'


### PR DESCRIPTION
This pull request updates the `initStyles` function in `src/initStyles.js` to reverse the order of `documentStyles` before iterating through its rules. This ensures that the styles are processed in reverse order, which may be necessary for specific styling priorities.

* [`src/initStyles.js`](diffhunk://#diff-ec8db93049ddd2c3ef8d16a763f7fc73e0f3594fbd41b8a3b67229e95ea839fbL28-R28): Modified the `initStyles` function to reverse the `documentStyles` array before processing its rules.